### PR TITLE
Fix launchd plist failing in dev mode

### DIFF
--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -83,9 +83,14 @@ export function generatePlist(task: Task): string {
   const binPath = getBinPath();
   const label = `com.reveille.task.${task.id}`;
 
+  // In dev mode (.ts file), use tsx as the runner since launchd can't execute .ts directly
+  const programArgs = binPath.endsWith(".ts")
+    ? ["npx", "tsx", binPath, "run", task.id]
+    : [binPath, "run", task.id];
+
   const plist: Record<string, unknown> = {
     Label: label,
-    ProgramArguments: [binPath, "run", task.id],
+    ProgramArguments: programArgs,
     WorkingDirectory: task.workingDir,
     EnvironmentVariables: {
       PATH: getUserPath(),


### PR DESCRIPTION
## Summary
- dev モード（`tsx` 経由）で `getBinPath()` が `.ts` ファイルを返すため、launchd が直接実行できず exit code 78 で失敗していた
- `.ts` ファイルの場合は `npx tsx` をプレフィックスとして `ProgramArguments` に設定するように修正

## Test plan
- [x] 既存テスト全パス (22件)
- [x] `npm run dev -- add` でタスク作成 → plist に `npx tsx` が含まれることを確認
- [x] `npm run dev -- run <id>` で手動実行成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)