### PR TITLE
Rename npm package to agent-reveille

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ reveille bridges this gap:
 ## Install
 
 ```bash
-npm install -g reveille
+npm install -g agent-reveille
 ```
 
 Or run directly:
 
 ```bash
-npx reveille
+npx agent-reveille
 ```
 
 Requires Node.js 20+.

--- a/README_ja.md
+++ b/README_ja.md
@@ -31,13 +31,13 @@ reveille はこのギャップを埋めます：
 ## インストール
 
 ```bash
-npm install -g reveille
+npm install -g agent-reveille
 ```
 
 または直接実行：
 
 ```bash
-npx reveille
+npx agent-reveille
 ```
 
 Node.js 20 以上が必要です。

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reveille",
+  "name": "agent-reveille",
   "version": "0.1.0",
   "description": "AI agent task scheduler with launchd integration",
   "type": "module",


### PR DESCRIPTION
## Summary
- npm パッケージ名を `reveille` → `agent-reveille` に変更
- CLI バイナリ名は `reveille` のまま（タイピング体験は変わらない）
- README の install コマンドを更新（英語・日本語両方）

## 変更理由
`agent-` プレフィックスにより npm 上で AI エージェントツールとして発見されやすくなる

🤖 Generated with [Claude Code](https://claude.com/claude-code)