### PR TITLE
Add E2E test infrastructure and ship/e2e skills

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: e2e
+description: "Run E2E tests for the reveille project and report results. Use this skill whenever the user mentions E2E tests, wants to run tests, says 'テスト実行', 'テストを走らせて', 'run e2e', 'run tests', or wants to verify that the CLI or components work correctly. Also trigger when the user asks to check if recent changes broke anything."
+allowed-tools: Bash(npm run test:e2e *), Bash(npm test *), Bash(npx vitest *), Read, Glob, Grep
+---
+
+# E2E Test Runner for Reveille
+
+Run and analyze end-to-end tests for the reveille CLI tool.
+
+## Test Architecture
+
+Reveille's E2E tests use two complementary approaches:
+
+1. **Component tests** (`test/e2e/components/`) — Use `ink-testing-library` to render Ink React components in-process. Fast, tests UI rendering and interactive behavior directly.
+   - `list.test.tsx` — TaskList component (empty state, table rendering, headers)
+   - `logs.test.tsx` — ExecutionList component (empty state, execution details, status)
+   - `dashboard.test.tsx` — Dashboard component (empty state, task display, detail panel)
+
+2. **CLI tests** (`test/e2e/cli/`) — Spawn `tsx bin/reveille.ts` as a child process. Tests the full CLI pipeline from argument parsing through file I/O.
+   - `lifecycle.test.ts` — Happy path: add → list → run → logs → remove
+   - `errors.test.ts` — Error handling: unknown command, missing ID, nonexistent task, help, version
+   - `execution.test.ts` — Task execution: success, failure, log file output
+
+### Test Isolation
+
+Tests are isolated from the user's real data via environment variables:
+- `REVEILLE_HOME` — Redirects all file paths to a temporary directory
+- `REVEILLE_SKIP_LAUNCHCTL` — Skips `launchctl load/unload` calls
+
+These are set automatically by the test helpers in `test/e2e/helpers/`.
+
+## How to Run
+
+Execute from the project root (`/Users/add/Github/agent-reveille`):
+
+```bash
+# Run E2E tests only
+npm run test:e2e
+
+# Run all tests (unit + E2E)
+npm test
+
+# Run a specific test file
+npx vitest run --project e2e test/e2e/cli/lifecycle.test.ts
+```
+
+## Steps
+
+1. Run `npm run test:e2e` and capture the output
+2. Parse the results:
+   - Count passed/failed tests and test files
+   - If all pass, report a brief success summary
+   - If any fail, proceed to diagnosis
+3. For each failing test:
+   - Read the failing test file to understand what it asserts
+   - Read the relevant source file that the test exercises
+   - Identify the root cause (assertion mismatch, changed output format, broken logic, etc.)
+4. Report findings to the user with:
+   - Overall pass/fail count
+   - For failures: test name, what it expected vs. what happened, and a suggested fix
+
+## Mapping Tests to Source Files
+
+| Test file | Tests | Source files |
+|-----------|-------|-------------|
+| `components/list.test.tsx` | TaskList rendering | `src/commands/list.tsx` |
+| `components/logs.test.tsx` | ExecutionList rendering | `src/commands/logs.tsx` |
+| `components/dashboard.test.tsx` | Dashboard rendering | `src/commands/dashboard.tsx` |
+| `cli/lifecycle.test.ts` | Full CLI workflow | `bin/reveille.ts`, `src/commands/add.tsx`, `src/commands/run.ts`, `src/commands/remove.ts`, `src/commands/list.tsx`, `src/commands/logs.tsx` |
+| `cli/errors.test.ts` | Error handling | `bin/reveille.ts`, `src/commands/run.ts`, `src/commands/remove.ts` |
+| `cli/execution.test.ts` | Task execution | `src/commands/run.ts`, `src/lib/executor.ts` |
+
+$ARGUMENTS

--- a/.claude/skills/e2e/evals/evals.json
+++ b/.claude/skills/e2e/evals/evals.json
@@ -1,0 +1,82 @@
+[
+  {
+    "query": "E2Eテスト実行して",
+    "should_trigger": true
+  },
+  {
+    "query": "テストを走らせて、さっきの変更で何か壊れてないか確認したい",
+    "should_trigger": true
+  },
+  {
+    "query": "run the e2e tests and tell me if anything broke",
+    "should_trigger": true
+  },
+  {
+    "query": "list.tsxのコンポーネントテストだけ回して結果教えて",
+    "should_trigger": true
+  },
+  {
+    "query": "CLIのライフサイクルテストが通るか確認してほしい。add→run→removeの流れ",
+    "should_trigger": true
+  },
+  {
+    "query": "npm run test:e2e 実行して、失敗してたら原因調べて",
+    "should_trigger": true
+  },
+  {
+    "query": "dashboardコンポーネントのレンダリングが壊れてないかテストで確認して",
+    "should_trigger": true
+  },
+  {
+    "query": "さっきscheduler.tsを変更したんだけど、テスト全部通るか見てくれる？",
+    "should_trigger": true
+  },
+  {
+    "query": "ink-testing-libraryで書いたテストの結果どうなってる？",
+    "should_trigger": true
+  },
+  {
+    "query": "テスト結果のサマリーを出して。何件パスで何件失敗か知りたい",
+    "should_trigger": true
+  },
+  {
+    "query": "毎朝9時にclaude codeでテストを自動実行するタスクをスケジュールして",
+    "should_trigger": false
+  },
+  {
+    "query": "reveille addで新しいタスクを追加したい。codexで毎日コードレビューさせたい",
+    "should_trigger": false
+  },
+  {
+    "query": "スケジュールされてるタスクの一覧を見せて",
+    "should_trigger": false
+  },
+  {
+    "query": "test/e2e/cli/lifecycle.test.ts にenable/disableのテストケースを追加して",
+    "should_trigger": false
+  },
+  {
+    "query": "vitest.config.tsのタイムアウト設定を60秒に変更して",
+    "should_trigger": false
+  },
+  {
+    "query": "executor.tsのexecuteTask関数にタイムアウトのユニットテストを書いて",
+    "should_trigger": false
+  },
+  {
+    "query": "package.jsonのtest:e2eスクリプトを修正して、--reporterオプションを追加したい",
+    "should_trigger": false
+  },
+  {
+    "query": "このプロジェクトのREADMEにテストの実行方法を書いて",
+    "should_trigger": false
+  },
+  {
+    "query": "reveille run task123 を実行して結果を見せて",
+    "should_trigger": false
+  },
+  {
+    "query": "ink-testing-libraryのAPIについて教えて。stdinの使い方がわからない",
+    "should_trigger": false
+  }
+]

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: ship
+description: "Commit staged changes and create a pull request on GitHub. Use this skill when the user says 'コミットして', 'PRを作って', 'プルリクエスト作成', 'ship it', 'commit and PR', 'push', 'マージしたい', or wants to commit their work and open a PR. Also trigger when the user says 'ship', 'リリースして', or asks to send changes upstream."
+allowed-tools: Bash(git *), Bash(gh pr *), Bash(gh api *), Bash(npm run test:e2e *), Bash(npm test *), Bash(npx vitest *), Read, Glob, Grep, Edit, Agent
+---
+
+# Ship — Commit & Pull Request
+
+Commit changes and create a pull request in one flow.
+
+## Workflow
+
+### 1. Assess the current state
+
+Run these in parallel:
+
+```bash
+git status
+git diff --stat
+git diff --staged --stat
+git log --oneline -5
+```
+
+Understand what's changed: modified files, new files, staged vs unstaged.
+
+### 2. Run quality gates
+
+Before committing, run these checks. Both must pass — if either fails, fix the issues before proceeding.
+
+#### a. tests
+
+```bash
+npm run test
+```
+
+If any test fails, read the failing test and the relevant source file, diagnose the issue, and fix it. Do not proceed to commit until all tests pass.
+
+#### b. Code simplifier
+
+Use the `code-simplifier` Agent (subagent_type: "code-simplifier") to review the changed code for reuse, quality, and efficiency. If it suggests fixes, apply them and re-run the E2E tests to make sure nothing broke.
+
+### 3. Stage files
+
+- Stage relevant files by name — avoid `git add -A` or `git add .` to prevent accidentally including sensitive files (.env, credentials) or large binaries
+- Never stage `node_modules/`, `.env`, or credential files
+- If nothing is staged and nothing is modified, tell the user there's nothing to commit
+
+### 4. Write the commit message
+
+Follow the project's established commit message style:
+
+```
+<Action verb> <brief title>
+
+- <Detail 1>
+- <Detail 2>
+- <Detail 3>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+- Action verbs: Add, Fix, Update, Refactor, Remove, Prepare, Rename
+- Title should be concise (under 72 chars)
+- Bullet points describe the key changes
+- Always include the Co-Authored-By footer
+
+Use a HEREDOC to pass the message:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<Title>
+
+- <detail>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 5. Push the branch
+
+```bash
+git push -u origin HEAD
+```
+
+If the branch doesn't have an upstream yet, the `-u` flag sets it.
+
+### 6. Create the pull request
+
+Use `gh pr create`:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <bullet 1>
+- <bullet 2>
+
+## Test plan
+- [ ] <verification step>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- Keep the PR title short (under 70 chars), matching the commit title
+- Summary section: 1-3 bullet points of what changed and why
+- Test plan section: how to verify the changes work
+- If a PR already exists for this branch, skip creation and tell the user
+
+### 7. Report back
+
+Show the user:
+- The commit hash and message
+- The PR URL
+
+## Important
+
+- Never force push (`--force`) unless the user explicitly asks
+- Never amend existing commits unless asked
+- Never skip pre-commit hooks (`--no-verify`)
+- If a hook fails, diagnose and fix rather than bypassing
+- Ask before committing if the changes look unintentional (e.g., only lock files changed)
+- The remote is `origin` at `github.com/mori-ri/agent-reveille`
+
+$ARGUMENTS

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
+        "ink-testing-library": "^4.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
@@ -1536,6 +1537,24 @@
       "peerDependencies": {
         "ink": ">=4.0.0",
         "react": ">=18.0.0"
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/ink-text-input": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dev": "tsx bin/reveille.ts",
     "build": "tsup",
     "test": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:e2e": "vitest run --project e2e",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
@@ -45,6 +47,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.3.0",
+    "ink-testing-library": "^4.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",

--- a/src/commands/add.tsx
+++ b/src/commands/add.tsx
@@ -20,7 +20,7 @@ interface TaskDraft {
   command: string;
 }
 
-function AddWizard() {
+export function AddWizard() {
   const { exit } = useApp();
   const [step, setStep] = useState<Step>("name");
   const [draft, setDraft] = useState<TaskDraft>({

--- a/src/commands/dashboard.tsx
+++ b/src/commands/dashboard.tsx
@@ -136,7 +136,7 @@ function HelpBar() {
   );
 }
 
-function Dashboard() {
+export function Dashboard() {
   const { exit } = useApp();
   const [tasks, setTasks] = useState<Task[]>(listTasks());
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/src/commands/list.tsx
+++ b/src/commands/list.tsx
@@ -4,7 +4,7 @@ import { listTasks, getTaskExecutions } from "../lib/tasks.js";
 import { isLoaded } from "../lib/scheduler.js";
 import { formatRelativeTime, formatSchedule, formatStatus } from "../utils/format.js";
 
-function TaskList() {
+export function TaskList() {
   const tasks = listTasks();
 
   if (tasks.length === 0) {

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -4,7 +4,7 @@ import { getTaskExecutions, getRecentExecutions, getTask } from "../lib/tasks.js
 import { formatDuration, formatRelativeTime, formatStatus } from "../utils/format.js";
 import type { Execution } from "../lib/schema.js";
 
-function ExecutionList({ executions, taskName }: { executions: Execution[]; taskName?: string }) {
+export function ExecutionList({ executions, taskName }: { executions: Execution[]; taskName?: string }) {
   if (executions.length === 0) {
     return (
       <Box paddingX={1}>

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -2,16 +2,18 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
 
-const home = homedir();
+function getHome(): string {
+  return process.env.REVEILLE_HOME ?? homedir();
+}
 
 export function getConfigDir(): string {
-  const dir = join(home, ".config", "reveille");
+  const dir = join(getHome(), ".config", "reveille");
   mkdirSync(dir, { recursive: true });
   return dir;
 }
 
 export function getDataDir(): string {
-  const dir = join(home, ".local", "share", "reveille");
+  const dir = join(getHome(), ".local", "share", "reveille");
   mkdirSync(dir, { recursive: true });
   return dir;
 }
@@ -32,7 +34,7 @@ export function getExecutionsFilePath(): string {
 }
 
 export function getPlistDir(): string {
-  return join(home, "Library", "LaunchAgents");
+  return join(getHome(), "Library", "LaunchAgents");
 }
 
 export function getPlistPath(taskId: string): string {

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { writeFileSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { parseExpression } from "cron-parser";
 import { serializePlist } from "../utils/plist.js";
@@ -116,41 +116,52 @@ export function generatePlist(task: Task): string {
   return serializePlist(plist as Record<string, never>);
 }
 
+function shouldSkipLaunchctl(): boolean {
+  return !!process.env.REVEILLE_SKIP_LAUNCHCTL;
+}
+
 export function installPlist(task: Task): void {
   const path = getPlistPath(task.id);
   const content = generatePlist(task);
 
   // Ensure LaunchAgents directory exists
   const dir = getPlistDir();
-  if (!existsSync(dir)) {
-    throw new Error(`LaunchAgents directory not found: ${dir}`);
-  }
+  mkdirSync(dir, { recursive: true });
 
-  // Unload first if already loaded
-  try {
-    execSync(`launchctl unload ${path}`, { stdio: "ignore" });
-  } catch {
-    // Ignore - may not be loaded
+  if (!shouldSkipLaunchctl()) {
+    // Unload first if already loaded
+    try {
+      execSync(`launchctl unload ${path}`, { stdio: "ignore" });
+    } catch {
+      // Ignore - may not be loaded
+    }
   }
 
   writeFileSync(path, content, "utf-8");
-  execSync(`launchctl load ${path}`);
+
+  if (!shouldSkipLaunchctl()) {
+    execSync(`launchctl load ${path}`);
+  }
 }
 
 export function uninstallPlist(taskId: string): void {
   const path = getPlistPath(taskId);
   if (!existsSync(path)) return;
 
-  try {
-    execSync(`launchctl unload ${path}`, { stdio: "ignore" });
-  } catch {
-    // Ignore
+  if (!shouldSkipLaunchctl()) {
+    try {
+      execSync(`launchctl unload ${path}`, { stdio: "ignore" });
+    } catch {
+      // Ignore
+    }
   }
 
   unlinkSync(path);
 }
 
 export function isLoaded(taskId: string): boolean {
+  if (shouldSkipLaunchctl()) return false;
+
   const label = `com.reveille.task.${taskId}`;
   try {
     execSync(`launchctl list ${label}`, { stdio: "ignore" });

--- a/test/e2e/cli/errors.test.ts
+++ b/test/e2e/cli/errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCLI } from "../helpers/cli.js";
+import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
+
+describe("CLI error handling", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("shows error for unknown command", async () => {
+    const result = await runCLI(["foobar"], env.tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Unknown command");
+  });
+
+  it("shows usage when run is called without ID", async () => {
+    const result = await runCLI(["run"], env.tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Usage");
+  });
+
+  it("shows error when running nonexistent task", async () => {
+    const result = await runCLI(["run", "nonexistent"], env.tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Task not found");
+  });
+
+  it("shows usage when remove is called without ID", async () => {
+    const result = await runCLI(["remove"], env.tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Usage");
+  });
+
+  it("shows error when removing nonexistent task", async () => {
+    const result = await runCLI(["remove", "nonexistent"], env.tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Task not found");
+  });
+
+  it("displays version", async () => {
+    const result = await runCLI(["--version"], env.tmpDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("reveille v");
+  });
+
+  it("displays help", async () => {
+    const result = await runCLI(["--help"], env.tmpDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Usage");
+    expect(result.stdout).toContain("Commands");
+  });
+});

--- a/test/e2e/cli/execution.test.ts
+++ b/test/e2e/cli/execution.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { runCLI } from "../helpers/cli.js";
+import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
+
+describe("CLI task execution", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("executes a successful command", async () => {
+    // Add task
+    const addResult = await runCLI(
+      ["add", "--name", "Success", "--cmd", "echo hello-success", "--dir", "/tmp"],
+      env.tmpDir,
+    );
+    const idMatch = addResult.stdout.match(/\(([a-zA-Z0-9_-]+)\)/);
+    const taskId = idMatch![1];
+
+    // Run
+    const runResult = await runCLI(["run", taskId], env.tmpDir);
+    expect(runResult.exitCode).toBe(0);
+    expect(runResult.stdout).toContain("Completed");
+    expect(runResult.stdout).toContain("exit code: 0");
+  });
+
+  it("executes a failing command", async () => {
+    const addResult = await runCLI(
+      ["add", "--name", "Failure", "--cmd", "exit 1", "--dir", "/tmp"],
+      env.tmpDir,
+    );
+    const idMatch = addResult.stdout.match(/\(([a-zA-Z0-9_-]+)\)/);
+    const taskId = idMatch![1];
+
+    const runResult = await runCLI(["run", taskId], env.tmpDir);
+    expect(runResult.exitCode).toBe(1);
+    expect(runResult.stdout).toContain("exit code: 1");
+  });
+
+  it("writes output to log files", async () => {
+    const marker = `test-marker-${Date.now()}`;
+    const addResult = await runCLI(
+      ["add", "--name", "LogTest", "--cmd", `echo ${marker}`, "--dir", "/tmp"],
+      env.tmpDir,
+    );
+    const idMatch = addResult.stdout.match(/\(([a-zA-Z0-9_-]+)\)/);
+    const taskId = idMatch![1];
+
+    await runCLI(["run", taskId], env.tmpDir);
+
+    // Check log files exist and contain the marker
+    const logDir = join(env.tmpDir, ".local", "share", "reveille", "logs", taskId);
+    const logFiles = readdirSync(logDir).filter((f) => f.endsWith(".stdout.log"));
+    expect(logFiles.length).toBeGreaterThan(0);
+
+    const logContent = readFileSync(join(logDir, logFiles[0]), "utf-8");
+    expect(logContent).toContain(marker);
+  });
+});

--- a/test/e2e/cli/lifecycle.test.ts
+++ b/test/e2e/cli/lifecycle.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { runCLI } from "../helpers/cli.js";
+import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
+
+describe("CLI lifecycle", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("lists empty state", async () => {
+    const result = await runCLI(["list"], env.tmpDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("No tasks configured");
+  });
+
+  it("adds a task via CLI flags", async () => {
+    const result = await runCLI(
+      ["add", "--name", "E2E Task", "--cmd", "echo hello", "--dir", "/tmp"],
+      env.tmpDir,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Task created");
+    expect(result.stdout).toContain("E2E Task");
+  });
+
+  it("full lifecycle: add → list → run → logs → remove", async () => {
+    // Add a task
+    const addResult = await runCLI(
+      ["add", "--name", "Lifecycle Test", "--cmd", "echo lifecycle-ok", "--dir", "/tmp"],
+      env.tmpDir,
+    );
+    expect(addResult.exitCode).toBe(0);
+
+    // Extract task ID from output: "Task created: Lifecycle Test (XXXXXXXX)"
+    const idMatch = addResult.stdout.match(/\(([a-zA-Z0-9_-]+)\)/);
+    expect(idMatch).not.toBeNull();
+    const taskId = idMatch![1];
+
+    // List should show the task
+    const listResult = await runCLI(["list"], env.tmpDir);
+    expect(listResult.exitCode).toBe(0);
+    expect(listResult.stdout).toContain("Lifecycle Test");
+
+    // Run the task
+    const runResult = await runCLI(["run", taskId], env.tmpDir);
+    expect(runResult.exitCode).toBe(0);
+    expect(runResult.stdout).toContain("Completed");
+    expect(runResult.stdout).toContain("exit code: 0");
+
+    // Check logs
+    const logsResult = await runCLI(["logs", taskId], env.tmpDir);
+    expect(logsResult.exitCode).toBe(0);
+    expect(logsResult.stdout).toContain("Execution Logs");
+
+    // Remove the task
+    const removeResult = await runCLI(["remove", taskId], env.tmpDir);
+    expect(removeResult.exitCode).toBe(0);
+    expect(removeResult.stdout).toContain("Removed");
+
+    // List should be empty again
+    const listAfter = await runCLI(["list"], env.tmpDir);
+    expect(listAfter.stdout).toContain("No tasks configured");
+  });
+
+  it("adds a task with cron schedule and writes plist", async () => {
+    const result = await runCLI(
+      [
+        "add",
+        "--name",
+        "Cron Task",
+        "--cmd",
+        "echo cron",
+        "--cron",
+        "0 9 * * *",
+        "--dir",
+        "/tmp",
+      ],
+      env.tmpDir,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Task created");
+  });
+});

--- a/test/e2e/components/dashboard.test.tsx
+++ b/test/e2e/components/dashboard.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "ink-testing-library";
+import { Dashboard } from "../../../src/commands/dashboard.js";
+import { createTask } from "../../../src/lib/tasks.js";
+import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
+
+describe("Dashboard component", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("displays empty state when no tasks exist", () => {
+    const { lastFrame } = render(<Dashboard />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("No tasks");
+  });
+
+  it("displays help bar with keybindings", () => {
+    const { lastFrame } = render(<Dashboard />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("j/k");
+    expect(frame).toContain("quit");
+  });
+
+  it("displays task list when tasks exist", () => {
+    createTask({
+      name: "Test Task",
+      agent: "custom",
+      command: "echo hello",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<Dashboard />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("Test Task");
+    expect(frame).toContain("custom");
+  });
+
+  it("shows selection indicator on first task", () => {
+    createTask({
+      name: "First Task",
+      agent: "custom",
+      command: "echo first",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<Dashboard />);
+    expect(lastFrame()).toContain("❯");
+  });
+
+  it("displays multiple tasks in list", () => {
+    createTask({
+      name: "Task One",
+      agent: "custom",
+      command: "echo one",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+    createTask({
+      name: "Task Two",
+      agent: "custom",
+      command: "echo two",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<Dashboard />);
+    const frame = lastFrame()!;
+
+    // Both tasks should be visible in the list
+    expect(frame).toContain("Task One");
+    expect(frame).toContain("Task Two");
+    // Detail panel shows first task by default
+    expect(frame).toContain("echo one");
+  });
+
+  it("displays detail panel for selected task", () => {
+    createTask({
+      name: "Detailed Task",
+      agent: "custom",
+      command: "echo detailed",
+      workingDir: "/tmp/test",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<Dashboard />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("Detailed Task");
+    expect(frame).toContain("echo detailed");
+    expect(frame).toContain("/tmp/test");
+  });
+});

--- a/test/e2e/components/list.test.tsx
+++ b/test/e2e/components/list.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "ink-testing-library";
+import { TaskList } from "../../../src/commands/list.js";
+import { createTask } from "../../../src/lib/tasks.js";
+import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
+
+describe("TaskList component", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("displays empty state message when no tasks exist", () => {
+    const { lastFrame } = render(<TaskList />);
+    expect(lastFrame()).toContain("No tasks configured");
+  });
+
+  it("displays task table when tasks exist", () => {
+    createTask({
+      name: "Daily Report",
+      agent: "claude",
+      command: 'claude -p "generate report"',
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<TaskList />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("Daily Report");
+    expect(frame).toContain("claude");
+    expect(frame).toContain("1 task(s)");
+  });
+
+  it("displays multiple tasks", () => {
+    createTask({
+      name: "Task A",
+      agent: "custom",
+      command: "echo a",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+    createTask({
+      name: "Task B",
+      agent: "custom",
+      command: "echo b",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<TaskList />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("Task A");
+    expect(frame).toContain("Task B");
+    expect(frame).toContain("2 task(s)");
+  });
+
+  it("displays table headers", () => {
+    createTask({
+      name: "Test",
+      agent: "custom",
+      command: "echo test",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const { lastFrame } = render(<TaskList />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("ID");
+    expect(frame).toContain("NAME");
+    expect(frame).toContain("AGENT");
+    expect(frame).toContain("SCHEDULE");
+    expect(frame).toContain("STATUS");
+    expect(frame).toContain("LAST RUN");
+  });
+});

--- a/test/e2e/components/logs.test.tsx
+++ b/test/e2e/components/logs.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render } from "ink-testing-library";
+import { ExecutionList } from "../../../src/commands/logs.js";
+import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
+import type { Execution } from "../../../src/lib/schema.js";
+
+describe("ExecutionList component", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("displays empty state when no executions", () => {
+    const { lastFrame } = render(<ExecutionList executions={[]} />);
+    expect(lastFrame()).toContain("No execution history");
+  });
+
+  it("displays execution details", () => {
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 5000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: "/tmp/stderr.log",
+        stdoutTail: "hello world",
+      },
+    ];
+
+    const { lastFrame } = render(<ExecutionList executions={executions} />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("Execution Logs");
+    expect(frame).toContain("Exit: 0");
+    expect(frame).toContain("hello world");
+  });
+
+  it("displays task name in title when provided", () => {
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 1000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: "/tmp/stderr.log",
+      },
+    ];
+
+    const { lastFrame } = render(
+      <ExecutionList executions={executions} taskName="My Task" />,
+    );
+    expect(lastFrame()).toContain("My Task");
+  });
+
+  it("displays failed execution status", () => {
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 2000).toISOString(),
+        exitCode: 1,
+        status: "failed",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: "/tmp/stderr.log",
+      },
+    ];
+
+    const { lastFrame } = render(<ExecutionList executions={executions} />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("Exit: 1");
+  });
+});

--- a/test/e2e/helpers/cli.ts
+++ b/test/e2e/helpers/cli.ts
@@ -1,0 +1,42 @@
+import { execFile } from "node:child_process";
+import { resolve } from "node:path";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
+const ENTRY_POINT = resolve(PROJECT_ROOT, "bin/reveille.ts");
+
+export interface CLIResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export function runCLI(args: string[], tmpDir: string): Promise<CLIResult> {
+  return new Promise((resolve) => {
+    execFile(
+      "npx",
+      ["tsx", ENTRY_POINT, ...args],
+      {
+        cwd: PROJECT_ROOT,
+        timeout: 15_000,
+        env: {
+          ...process.env,
+          REVEILLE_HOME: tmpDir,
+          REVEILLE_SKIP_LAUNCHCTL: "1",
+          NO_COLOR: "1",
+          FORCE_COLOR: "0",
+        },
+      },
+      (error, stdout, stderr) => {
+        let exitCode = 0;
+        if (error) {
+          exitCode = typeof error.code === "number" ? error.code : 1;
+        }
+        resolve({
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
+          exitCode,
+        });
+      },
+    );
+  });
+}

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+export interface TestEnv {
+  tmpDir: string;
+  cleanup: () => void;
+}
+
+export function createTestEnv(): TestEnv {
+  const tmpDir = mkdtempSync(join(tmpdir(), "reveille-e2e-"));
+
+  // Create directory structure that paths.ts expects
+  mkdirSync(join(tmpDir, ".config", "reveille"), { recursive: true });
+  mkdirSync(join(tmpDir, ".local", "share", "reveille", "logs"), { recursive: true });
+  mkdirSync(join(tmpDir, "Library", "LaunchAgents"), { recursive: true });
+
+  // Set environment variables for in-process tests (ink-testing-library)
+  const prevHome = process.env.REVEILLE_HOME;
+  const prevSkip = process.env.REVEILLE_SKIP_LAUNCHCTL;
+  process.env.REVEILLE_HOME = tmpDir;
+  process.env.REVEILLE_SKIP_LAUNCHCTL = "1";
+
+  return {
+    tmpDir,
+    cleanup() {
+      // Restore environment
+      if (prevHome === undefined) {
+        delete process.env.REVEILLE_HOME;
+      } else {
+        process.env.REVEILLE_HOME = prevHome;
+      }
+      if (prevSkip === undefined) {
+        delete process.env.REVEILLE_SKIP_LAUNCHCTL;
+      } else {
+        process.env.REVEILLE_SKIP_LAUNCHCTL = prevSkip;
+      }
+      // Remove temp directory
+      rmSync(tmpDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/test/lib/tasks.test.ts
+++ b/test/lib/tasks.test.ts
@@ -1,22 +1,23 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createTask, getTask, listTasks, updateTask, deleteTask } from "../../src/lib/tasks.js";
 import { getTasksFilePath, getExecutionsFilePath } from "../../src/lib/paths.js";
-import { writeFileSync, unlinkSync, existsSync } from "node:fs";
+import { writeFileSync } from "node:fs";
+import { createTestEnv, type TestEnv } from "../helpers/setup.js";
 
 describe("tasks", () => {
-  const tasksPath = getTasksFilePath();
-  const execsPath = getExecutionsFilePath();
+  let env: TestEnv;
 
   beforeEach(() => {
-    // Start with clean state
+    env = createTestEnv();
+
+    const tasksPath = getTasksFilePath();
+    const execsPath = getExecutionsFilePath();
     writeFileSync(tasksPath, "[]", "utf-8");
     writeFileSync(execsPath, "[]", "utf-8");
   });
 
   afterEach(() => {
-    // Clean up
-    if (existsSync(tasksPath)) writeFileSync(tasksPath, "[]", "utf-8");
-    if (existsSync(execsPath)) writeFileSync(execsPath, "[]", "utf-8");
+    env.cleanup();
   });
 
   it("should create a task", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: "unit",
+          include: ["test/lib/**/*.test.ts", "test/utils/**/*.test.ts"],
+        },
+      },
+      {
+        test: {
+          name: "e2e",
+          include: ["test/e2e/**/*.test.{ts,tsx}"],
+          testTimeout: 30_000,
+          hookTimeout: 15_000,
+        },
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- ink-testing-library によるコンポーネントテスト + 子プロセスによる CLI E2E テストを導入
- `REVEILLE_HOME` / `REVEILLE_SKIP_LAUNCHCTL` 環境変数でテスト分離を実現
- `/e2e` スキル（テスト実行＋診断）と `/ship` スキル（コミット＋PR作成）を追加
- vitest projects 設定で unit/e2e を分離、共有テストヘルパーを整備

## Test plan
- [x] `npm test` — 全50テスト（unit 22 + e2e 28）通過
- [x] `npm run test:e2e` — E2E 28テスト通過
- [x] `npm run dev -- list` — REVEILLE_HOME 未設定で既存動作に変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)