### PR TITLE
Fix dev-mode plist using unexecutable .ts path

### DIFF
--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
 
 function getHome(): string {
   return process.env.REVEILLE_HOME ?? homedir();
@@ -42,5 +43,22 @@ export function getPlistPath(taskId: string): string {
 }
 
 export function getBinPath(): string {
-  return process.argv[1] ?? "reveille";
+  const argv1 = process.argv[1] ?? "";
+
+  // In dev mode (.ts source), resolve the installed binary for plist generation
+  if (argv1.endsWith(".ts")) {
+    try {
+      const resolved = execSync("which reveille", {
+        encoding: "utf-8",
+        timeout: 3000,
+      }).trim();
+      if (resolved && existsSync(resolved)) {
+        return resolved;
+      }
+    } catch {
+      // not installed globally
+    }
+  }
+
+  return argv1 || "reveille";
 }


### PR DESCRIPTION
## Summary
- `getBinPath()` が開発モード（`npx tsx bin/reveille.ts`）で `.ts` ファイルパスをplistに書き込んでいた
- launchdは `.ts` を直接実行できず、終了コード78で定期実行が失敗
- dev mode検出時に `which reveille` でインストール済みバイナリを解決するよう修正

## Test plan
- [x] 全50テスト（unit + E2E）パス
- [x] dev modeで `reveille add` → plistに `/opt/homebrew/bin/reveille` が書き込まれることを確認
- [ ] `npm run build && npm i -g .` 後にplistパスが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)