### PR TITLE
ログ表示の改善: 絶対時刻・stderr表示・表示オプション追加

### DIFF
--- a/bin/reveille.ts
+++ b/bin/reveille.ts
@@ -59,6 +59,9 @@ function printHelp() {
     remove, rm <id>    Remove a task
     run <id>           Execute a task immediately
     logs [id]          View execution logs
+      -n, --lines <N>    Number of stdout preview lines (default: 3)
+      --stderr           Include stderr output
+      --full             Show full stdout instead of tail
     enable <id>        Enable task (load launchd plist)
     disable <id>       Disable task (unload launchd plist)
     dashboard          Open interactive TUI dashboard

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -1,10 +1,27 @@
 import React from "react";
 import { render, Box, Text } from "ink";
-import { getTaskExecutions, getRecentExecutions, getTask } from "../lib/tasks.js";
-import { formatDuration, formatRelativeTime, formatStatus } from "../utils/format.js";
+import { getTaskExecutions, getRecentExecutions, getTask, listTasks } from "../lib/tasks.js";
+import { formatDuration, formatRelativeTime, formatAbsoluteTime, formatStatus } from "../utils/format.js";
+import { readLogFile } from "../lib/executor.js";
 import type { Execution } from "../lib/schema.js";
 
-export function ExecutionList({ executions, taskName }: { executions: Execution[]; taskName?: string }) {
+interface ExecutionListProps {
+  executions: Execution[];
+  taskName?: string;
+  taskMap?: Record<string, string>;
+  lines?: number;
+  showStderr?: boolean;
+  showFull?: boolean;
+}
+
+export function ExecutionList({
+  executions,
+  taskName,
+  taskMap,
+  lines = 3,
+  showStderr = false,
+  showFull = false,
+}: ExecutionListProps) {
   if (executions.length === 0) {
     return (
       <Box paddingX={1}>
@@ -27,22 +44,70 @@ export function ExecutionList({ executions, taskName }: { executions: Execution[
               )
             : "running...";
 
+        const absoluteTime = formatAbsoluteTime(exec.startedAt);
+        const relativeTime = formatRelativeTime(exec.startedAt);
+
+        // Determine stdout content to show
+        let stdoutContent: string | undefined;
+        if (showFull && exec.stdoutPath) {
+          const fullLog = readLogFile(exec.stdoutPath);
+          if (fullLog !== "(log file not found)") {
+            stdoutContent = fullLog.trimEnd();
+          }
+        } else if (exec.stdoutTail) {
+          stdoutContent = exec.stdoutTail
+            .split("\n")
+            .slice(-lines)
+            .join("\n");
+        }
+
+        // Determine stderr content
+        let stderrContent: string | undefined;
+        if (showStderr && exec.stderrPath) {
+          const stderrLog = readLogFile(exec.stderrPath);
+          if (stderrLog !== "(log file not found)") {
+            const trimmed = stderrLog.trim();
+            if (trimmed.length > 0) {
+              stderrContent = trimmed;
+            }
+          }
+        }
+
+        // Task info when showing all tasks
+        const taskLabel = taskMap && taskMap[exec.taskId]
+          ? `${taskMap[exec.taskId]} (${exec.taskId})`
+          : undefined;
+
         return (
           <Box key={exec.id} flexDirection="column" marginBottom={1}>
+            {taskLabel && (
+              <Text bold color="white">
+                {taskLabel}
+              </Text>
+            )}
             <Box>
               <Text>{formatStatus(exec.status)}</Text>
               <Text color="gray"> | </Text>
-              <Text>{formatRelativeTime(exec.startedAt)}</Text>
+              <Text>{absoluteTime}</Text>
+              <Text color="gray"> ({relativeTime})</Text>
               <Text color="gray"> | </Text>
               <Text>Duration: {duration}</Text>
               <Text color="gray"> | </Text>
               <Text>Exit: {exec.exitCode ?? "-"}</Text>
             </Box>
-            {exec.stdoutTail && (
+            {exec.stdoutPath && (
               <Box marginLeft={2}>
-                <Text color="gray">
-                  {exec.stdoutTail.split("\n").slice(-3).join("\n")}
-                </Text>
+                <Text color="gray">Log: {exec.stdoutPath}</Text>
+              </Box>
+            )}
+            {stdoutContent && (
+              <Box marginLeft={2} flexDirection="column">
+                <Text color="gray">{stdoutContent}</Text>
+              </Box>
+            )}
+            {stderrContent && (
+              <Box marginLeft={2} flexDirection="column">
+                <Text color="red">{stderrContent}</Text>
               </Box>
             )}
           </Box>
@@ -52,8 +117,39 @@ export function ExecutionList({ executions, taskName }: { executions: Execution[
   );
 }
 
+function parseArgs(args: string[]): {
+  id?: string;
+  lines: number;
+  showStderr: boolean;
+  showFull: boolean;
+} {
+  let id: string | undefined;
+  let lines = 3;
+  let showStderr = false;
+  let showFull = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--lines" || arg === "-n") {
+      const next = args[i + 1];
+      if (next && !next.startsWith("-")) {
+        lines = parseInt(next, 10);
+        i++;
+      }
+    } else if (arg === "--stderr") {
+      showStderr = true;
+    } else if (arg === "--full") {
+      showFull = true;
+    } else if (!arg.startsWith("-")) {
+      id = arg;
+    }
+  }
+
+  return { id, lines, showStderr, showFull };
+}
+
 export default async function logs(args: string[]) {
-  const id = args[0];
+  const { id, lines, showStderr, showFull } = parseArgs(args);
 
   let instance;
   if (id) {
@@ -63,10 +159,31 @@ export default async function logs(args: string[]) {
       process.exit(1);
     }
     const executions = getTaskExecutions(id);
-    instance = render(<ExecutionList executions={executions} taskName={task.name} />);
+    instance = render(
+      <ExecutionList
+        executions={executions}
+        taskName={task.name}
+        lines={lines}
+        showStderr={showStderr}
+        showFull={showFull}
+      />,
+    );
   } else {
     const executions = getRecentExecutions();
-    instance = render(<ExecutionList executions={executions} />);
+    const tasks = listTasks();
+    const taskMap: Record<string, string> = {};
+    for (const t of tasks) {
+      taskMap[t.id] = t.name;
+    }
+    instance = render(
+      <ExecutionList
+        executions={executions}
+        taskMap={taskMap}
+        lines={lines}
+        showStderr={showStderr}
+        showFull={showFull}
+      />,
+    );
   }
 
   instance.unmount();

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -19,6 +19,22 @@ export function formatRelativeTime(date: string | Date): string {
   return formatDistanceToNow(d, { addSuffix: true });
 }
 
+export function formatAbsoluteTime(isoString: string): string {
+  const d = new Date(isoString);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hours = String(d.getHours()).padStart(2, "0");
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
+export function formatFullTime(isoString: string): string {
+  const absolute = formatAbsoluteTime(isoString);
+  const relative = formatRelativeTime(isoString);
+  return `${absolute} (${relative})`;
+}
+
 export function formatSchedule(task: Task): string {
   if (task.scheduleType === "cron" && task.scheduleCron) {
     try {

--- a/test/e2e/components/logs.test.tsx
+++ b/test/e2e/components/logs.test.tsx
@@ -4,6 +4,8 @@ import { render } from "ink-testing-library";
 import { ExecutionList } from "../../../src/commands/logs.js";
 import { createTestEnv, type TestEnv } from "../../helpers/setup.js";
 import type { Execution } from "../../../src/lib/schema.js";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 describe("ExecutionList component", () => {
   let env: TestEnv;
@@ -80,5 +82,160 @@ describe("ExecutionList component", () => {
     const { lastFrame } = render(<ExecutionList executions={executions} />);
     const frame = lastFrame()!;
     expect(frame).toContain("Exit: 1");
+  });
+
+  it("displays absolute datetime alongside relative time", () => {
+    const startDate = new Date(2026, 3, 4, 9, 3, 0);
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: startDate.toISOString(),
+        finishedAt: new Date(startDate.getTime() + 5000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: "/tmp/stderr.log",
+      },
+    ];
+
+    const { lastFrame } = render(<ExecutionList executions={executions} />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("2026-04-04 09:03");
+  });
+
+  it("displays task name and task ID when showing all tasks", () => {
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 5000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: "/tmp/stderr.log",
+      },
+    ];
+
+    const taskMap = { "task-1": "Daily Lint" };
+    const { lastFrame } = render(
+      <ExecutionList executions={executions} taskMap={taskMap} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain("Daily Lint");
+    expect(frame).toContain("task-1");
+  });
+
+  it("shows log file path for each execution", () => {
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 5000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: "/tmp/test-stdout.log",
+        stderrPath: "/tmp/test-stderr.log",
+      },
+    ];
+
+    const { lastFrame } = render(<ExecutionList executions={executions} />);
+    const frame = lastFrame()!;
+    expect(frame).toContain("/tmp/test-stdout.log");
+  });
+
+  it("respects lines option to control stdout preview lines", () => {
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 5000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: "/tmp/stderr.log",
+        stdoutTail: "line1\nline2\nline3\nline4\nline5",
+      },
+    ];
+
+    // Default: 3 lines
+    const { lastFrame: frame3 } = render(
+      <ExecutionList executions={executions} />,
+    );
+    const output3 = frame3()!;
+    expect(output3).toContain("line3");
+    expect(output3).toContain("line5");
+    expect(output3).not.toContain("line2");
+
+    // Custom: 5 lines
+    const { lastFrame: frame5 } = render(
+      <ExecutionList executions={executions} lines={5} />,
+    );
+    const output5 = frame5()!;
+    expect(output5).toContain("line1");
+    expect(output5).toContain("line5");
+  });
+
+  it("shows stderr content when stderr flag is set", () => {
+    const stderrFile = join(env.tmpDir, "stderr-test.log");
+    writeFileSync(stderrFile, "Warning: something went wrong\nError: fatal");
+
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 5000).toISOString(),
+        exitCode: 1,
+        status: "failed",
+        stdoutPath: "/tmp/stdout.log",
+        stderrPath: stderrFile,
+        stdoutTail: "some output",
+      },
+    ];
+
+    // Without stderr flag: no stderr content
+    const { lastFrame: frameWithout } = render(
+      <ExecutionList executions={executions} />,
+    );
+    expect(frameWithout()!).not.toContain("Warning: something went wrong");
+
+    // With stderr flag: show stderr content
+    const { lastFrame: frameWith } = render(
+      <ExecutionList executions={executions} showStderr={true} />,
+    );
+    expect(frameWith()!).toContain("Warning: something went wrong");
+  });
+
+  it("shows full stdout when full flag is set", () => {
+    const stdoutFile = join(env.tmpDir, "stdout-test.log");
+    writeFileSync(
+      stdoutFile,
+      "full line 1\nfull line 2\nfull line 3\nfull line 4\nfull line 5",
+    );
+
+    const executions: Execution[] = [
+      {
+        id: "exec-1",
+        taskId: "task-1",
+        startedAt: new Date().toISOString(),
+        finishedAt: new Date(Date.now() + 5000).toISOString(),
+        exitCode: 0,
+        status: "success",
+        stdoutPath: stdoutFile,
+        stderrPath: "/tmp/stderr.log",
+        stdoutTail: "full line 4\nfull line 5",
+      },
+    ];
+
+    const { lastFrame } = render(
+      <ExecutionList executions={executions} showFull={true} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain("full line 1");
+    expect(frame).toContain("full line 5");
   });
 });

--- a/test/utils/format.test.ts
+++ b/test/utils/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { formatDuration } from "../../src/utils/format.js";
+import {
+  formatDuration,
+  formatAbsoluteTime,
+  formatFullTime,
+  formatRelativeTime,
+} from "../../src/utils/format.js";
 
 describe("formatDuration", () => {
   it("should format seconds", () => {
@@ -19,5 +24,46 @@ describe("formatDuration", () => {
 
   it("should handle zero", () => {
     expect(formatDuration(0)).toBe("0s");
+  });
+});
+
+describe("formatAbsoluteTime", () => {
+  it("should format ISO string to YYYY-MM-DD HH:mm", () => {
+    // Use a fixed date to avoid timezone issues in tests
+    const date = new Date(2026, 3, 4, 9, 3, 0); // April 4, 2026 09:03
+    const result = formatAbsoluteTime(date.toISOString());
+    expect(result).toBe("2026-04-04 09:03");
+  });
+
+  it("should handle midnight", () => {
+    const date = new Date(2026, 0, 1, 0, 0, 0); // Jan 1, 2026 00:00
+    const result = formatAbsoluteTime(date.toISOString());
+    expect(result).toBe("2026-01-01 00:00");
+  });
+
+  it("should pad single-digit months and hours", () => {
+    const date = new Date(2026, 0, 5, 3, 7, 0); // Jan 5, 2026 03:07
+    const result = formatAbsoluteTime(date.toISOString());
+    expect(result).toBe("2026-01-05 03:07");
+  });
+});
+
+describe("formatFullTime", () => {
+  it("should return absolute time with relative time in parentheses", () => {
+    const now = new Date();
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+    const result = formatFullTime(twoHoursAgo.toISOString());
+    const absolute = formatAbsoluteTime(twoHoursAgo.toISOString());
+    // Should start with the absolute time
+    expect(result).toContain(absolute);
+    // Should contain relative part in parentheses
+    expect(result).toMatch(/\(.+ago\)/);
+  });
+
+  it("should use formatRelativeTime for the relative part", () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+    const result = formatFullTime(fiveMinutesAgo.toISOString());
+    const relative = formatRelativeTime(fiveMinutesAgo.toISOString());
+    expect(result).toContain(relative);
   });
 });


### PR DESCRIPTION
## Summary
- 実行日時を絶対表示+相対表示で併記（例: `2026-04-04 09:03 (2 hours ago)`）
- 全タスク表示時にタスク名・IDを表示
- `--stderr`, `--full`, `-n/--lines` フラグを追加
- ログファイルパスを表示

Closes #23

## Test plan
- [ ] `reveille logs` で絶対日時が表示されること
- [ ] `reveille logs` でタスク名・IDが表示されること
- [ ] `reveille logs --stderr` で stderr が表示されること
- [ ] `reveille logs --full` でフルログが表示されること
- [ ] `reveille logs -n 10` で行数指定が効くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)