### PR TITLE
Add reveille doctor command

### DIFF
--- a/.claude/skills/reveille/SKILL.md
+++ b/.claude/skills/reveille/SKILL.md
@@ -24,6 +24,7 @@ reveille logs [id] # View execution history
 reveille enable <id>   # Enable scheduling (load launchd plist)
 reveille disable <id>  # Disable scheduling (unload launchd plist)
 reveille remove <id>   # Delete a task and its plist
+reveille doctor        # Diagnose common configuration issues
 ```
 
 ### Non-interactive task creation
@@ -64,6 +65,10 @@ Run `reveille disable <id>` to unload the launchd plist without deleting the tas
 ### "Remove a task"
 
 Run `reveille remove <id>` after confirming with the user.
+
+### "Something's not working" / "Why won't my task run?"
+
+Run `reveille doctor` to diagnose issues. Review the output and address any failures.
 
 ### "Run it now"
 

--- a/bin/reveille.ts
+++ b/bin/reveille.ts
@@ -31,6 +31,9 @@ async function main() {
     case "dashboard":
       await (await import("../src/commands/dashboard.js")).default(args.slice(1));
       break;
+    case "doctor":
+      await (await import("../src/commands/doctor.js")).default(args.slice(1));
+      break;
     case "help":
     case "--help":
     case "-h":
@@ -63,6 +66,7 @@ function printHelp() {
     logs [id]          View execution logs
     enable <id>        Enable task (load launchd plist)
     disable <id>       Disable task (unload launchd plist)
+    doctor             Diagnose common issues
     dashboard          Open interactive TUI dashboard
 
   Options:

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,48 @@
+import chalk from "chalk";
+import { type CheckStatus, type DiagnosticReport, runDiagnostics } from "../lib/doctor.js";
+
+const ICONS: Record<CheckStatus, string> = {
+  pass: chalk.green("✓"),
+  fail: chalk.red("✗"),
+  warn: chalk.yellow("⚠"),
+};
+
+function printReport(report: DiagnosticReport): void {
+  console.log("");
+  console.log(chalk.bold("reveille doctor"));
+  console.log("");
+
+  for (const check of report.checks) {
+    const icon = ICONS[check.status];
+    console.log(`  ${icon} ${check.message}`);
+    if (check.detail) {
+      console.log(chalk.gray(`    ${check.detail}`));
+    }
+  }
+
+  console.log("");
+
+  const counts: Record<CheckStatus, number> = { pass: 0, fail: 0, warn: 0 };
+  for (const check of report.checks) {
+    counts[check.status]++;
+  }
+
+  if (report.hasFail) {
+    console.log(
+      `${chalk.red(`${counts.fail} issue(s) found.`)} ${counts.warn} warning(s), ${counts.pass} passed.`,
+    );
+  } else if (report.hasWarn) {
+    console.log(`${chalk.yellow(`${counts.warn} warning(s).`)} ${counts.pass} passed.`);
+  } else {
+    console.log(chalk.green(`All ${counts.pass} checks passed.`));
+  }
+}
+
+export default async function doctor(_args: string[]): Promise<void> {
+  const report = runDiagnostics();
+  printReport(report);
+
+  if (report.hasFail) {
+    process.exit(1);
+  }
+}

--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -1,0 +1,250 @@
+import { execSync } from "node:child_process";
+import { constants, accessSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { detectInstalledAgents, getAgent } from "./agents.js";
+import { getBinPath, getConfigDir, getDataDir, getPlistDir, getPlistPath } from "./paths.js";
+import { getUserPath, isLoaded } from "./scheduler.js";
+import type { AgentId, Task } from "./schema.js";
+import { listTasks } from "./tasks.js";
+
+export type CheckStatus = "pass" | "fail" | "warn";
+
+export interface CheckResult {
+  name: string;
+  status: CheckStatus;
+  message: string;
+  detail?: string;
+}
+
+export interface DiagnosticReport {
+  checks: CheckResult[];
+  hasFail: boolean;
+  hasWarn: boolean;
+}
+
+function checkReveilleBinary(): CheckResult {
+  const binPath = getBinPath();
+  if (binPath && existsSync(binPath)) {
+    return {
+      name: "reveille-binary",
+      status: "pass",
+      message: `reveille binary found at ${binPath}`,
+    };
+  }
+
+  // Try which as fallback
+  try {
+    const resolved = execSync("which reveille", {
+      encoding: "utf-8",
+      timeout: 3000,
+    }).trim();
+    if (resolved) {
+      return {
+        name: "reveille-binary",
+        status: "pass",
+        message: `reveille binary found at ${resolved}`,
+      };
+    }
+  } catch {
+    // not found
+  }
+
+  return {
+    name: "reveille-binary",
+    status: "fail",
+    message: "reveille binary not found",
+    detail: "launchd plists will fail to execute without the reveille binary on PATH",
+  };
+}
+
+function checkAgentBinaries(): CheckResult[] {
+  const agents = detectInstalledAgents();
+  return agents.map((agent) => ({
+    name: `agent-${agent.id}`,
+    status: agent.installed ? "pass" : "warn",
+    message: agent.installed
+      ? `${agent.name} (${agent.binary}) found`
+      : `${agent.name} (${agent.binary}) not found`,
+  }));
+}
+
+function checkPathConfiguration(): CheckResult {
+  const path = getUserPath();
+  const home = homedir();
+  const expectedDirs = ["/usr/local/bin", "/opt/homebrew/bin", `${home}/.local/bin`];
+
+  const pathDirs = path.split(":");
+  const missing = expectedDirs.filter((dir) => !pathDirs.includes(dir));
+
+  if (missing.length === 0) {
+    return {
+      name: "path-config",
+      status: "pass",
+      message: "Login shell PATH includes standard locations",
+    };
+  }
+
+  return {
+    name: "path-config",
+    status: "warn",
+    message: "Login shell PATH missing some standard locations",
+    detail: `Missing: ${missing.join(", ")}`,
+  };
+}
+
+function checkDirectory(name: string, dirPath: string): CheckResult {
+  const displayPath = dirPath.replace(homedir(), "~");
+
+  if (!existsSync(dirPath)) {
+    return {
+      name: `dir-${name}`,
+      status: "fail",
+      message: `${name} directory missing (${displayPath})`,
+    };
+  }
+
+  try {
+    accessSync(dirPath, constants.W_OK);
+    return {
+      name: `dir-${name}`,
+      status: "pass",
+      message: `${name} directory writable (${displayPath})`,
+    };
+  } catch {
+    return {
+      name: `dir-${name}`,
+      status: "fail",
+      message: `${name} directory not writable (${displayPath})`,
+      detail: "Check file permissions",
+    };
+  }
+}
+
+function checkDirectories(): CheckResult[] {
+  return [
+    checkDirectory("Config", getConfigDir()),
+    checkDirectory("Data", getDataDir()),
+    checkDirectory("LaunchAgents", getPlistDir()),
+  ];
+}
+
+function checkLaunchctlConnectivity(): CheckResult {
+  if (process.env.REVEILLE_SKIP_LAUNCHCTL) {
+    return {
+      name: "launchctl",
+      status: "pass",
+      message: "launchctl check skipped (test environment)",
+    };
+  }
+
+  try {
+    execSync("launchctl list", { stdio: "ignore", timeout: 5000 });
+    return {
+      name: "launchctl",
+      status: "pass",
+      message: "launchctl is responsive",
+    };
+  } catch {
+    return {
+      name: "launchctl",
+      status: "fail",
+      message: "launchctl is not responding",
+      detail: "macOS launchd may be misconfigured",
+    };
+  }
+}
+
+/** Build a lookup of agent binary availability, keyed by AgentId. Runs `which` once per agent. */
+function buildAgentInstalledMap(): Map<AgentId, boolean> {
+  const agents = detectInstalledAgents();
+  return new Map(agents.map((a) => [a.id, a.installed]));
+}
+
+function checkTaskWorkdir(task: Task): CheckResult {
+  const exists = existsSync(task.workingDir);
+  return {
+    name: `task-${task.id}-workdir`,
+    status: exists ? "pass" : "fail",
+    message: `[${task.name}] Working directory ${exists ? "exists" : "missing"}`,
+    detail: task.workingDir,
+  };
+}
+
+function checkTaskPlist(task: Task): CheckResult {
+  const plistPath = getPlistPath(task.id);
+  const exists = existsSync(plistPath);
+  return {
+    name: `task-${task.id}-plist`,
+    status: exists ? "pass" : "fail",
+    message: `[${task.name}] Plist file ${exists ? "present" : "missing"}`,
+    detail: exists
+      ? undefined
+      : `Task is enabled but plist not found — run: reveille enable ${task.id}`,
+  };
+}
+
+function checkTaskLoaded(task: Task): CheckResult {
+  const loaded = isLoaded(task.id);
+  return {
+    name: `task-${task.id}-loaded`,
+    status: loaded ? "pass" : "warn",
+    message: `[${task.name}] Plist ${loaded ? "loaded in" : "not loaded in"} launchd`,
+    detail: loaded ? undefined : `May need to re-enable after reboot: reveille enable ${task.id}`,
+  };
+}
+
+function checkTaskAgent(task: Task, agentInstalledMap: Map<AgentId, boolean>): CheckResult | null {
+  if (task.agent === "custom") return null;
+
+  const agent = getAgent(task.agent);
+  if (!agent) return null;
+
+  const installed = agentInstalledMap.get(task.agent) ?? false;
+  return {
+    name: `task-${task.id}-agent`,
+    status: installed ? "pass" : "warn",
+    message: `[${task.name}] Agent binary ${installed ? "available" : "not found"} (${agent.binary})`,
+  };
+}
+
+function checkTaskHealth(tasks: Task[]): CheckResult[] {
+  const agentInstalledMap = buildAgentInstalledMap();
+  const results: CheckResult[] = [];
+
+  for (const task of tasks) {
+    results.push(checkTaskWorkdir(task));
+
+    if (task.enabled && task.scheduleType !== "manual") {
+      results.push(checkTaskPlist(task));
+      results.push(checkTaskLoaded(task));
+    }
+
+    const agentCheck = checkTaskAgent(task, agentInstalledMap);
+    if (agentCheck) {
+      results.push(agentCheck);
+    }
+  }
+
+  return results;
+}
+
+export function runDiagnostics(): DiagnosticReport {
+  const checks: CheckResult[] = [];
+
+  checks.push(checkReveilleBinary());
+  checks.push(...checkAgentBinaries());
+  checks.push(checkPathConfiguration());
+  checks.push(...checkDirectories());
+  checks.push(checkLaunchctlConnectivity());
+
+  const tasks = listTasks();
+  if (tasks.length > 0) {
+    checks.push(...checkTaskHealth(tasks));
+  }
+
+  return {
+    checks,
+    hasFail: checks.some((c) => c.status === "fail"),
+    hasWarn: checks.some((c) => c.status === "warn"),
+  };
+}

--- a/src/lib/scheduler.ts
+++ b/src/lib/scheduler.ts
@@ -65,7 +65,7 @@ export function cronToIntervalSeconds(cron: string): number | null {
   return null;
 }
 
-function getUserPath(): string {
+export function getUserPath(): string {
   try {
     const shell = process.env.SHELL ?? "/bin/zsh";
     const path = execSync(`${shell} -l -c 'echo $PATH'`, {

--- a/test/e2e/cli/doctor.test.ts
+++ b/test/e2e/cli/doctor.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type TestEnv, createTestEnv } from "../../helpers/setup.js";
+import { runCLI } from "../helpers/cli.js";
+
+describe("CLI doctor", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("runs doctor with exit code 0 when no tasks exist", async () => {
+    const result = await runCLI(["doctor"], env.tmpDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("reveille doctor");
+    expect(result.stdout).toContain("passed");
+  });
+
+  it("shows agent check results", async () => {
+    const result = await runCLI(["doctor"], env.tmpDir);
+    // Should mention at least one agent
+    expect(result.stdout).toMatch(/Claude Code|Codex CLI|Gemini CLI|Aider/);
+  });
+
+  it("shows directory checks", async () => {
+    const result = await runCLI(["doctor"], env.tmpDir);
+    expect(result.stdout).toContain("Config");
+    expect(result.stdout).toContain("Data");
+    expect(result.stdout).toContain("LaunchAgents");
+  });
+
+  it("exits with code 1 when a task has issues", async () => {
+    // Create a task with nonexistent working directory
+    const addResult = await runCLI(
+      ["add", "--name", "Bad Task", "--cmd", "echo test", "--dir", "/nonexistent/path/abc123xyz"],
+      env.tmpDir,
+    );
+    expect(addResult.exitCode).toBe(0);
+
+    const result = await runCLI(["doctor"], env.tmpDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("Working directory missing");
+    expect(result.stdout).toContain("issue(s) found");
+  });
+
+  it("doctor appears in help output", async () => {
+    const result = await runCLI(["--help"], env.tmpDir);
+    expect(result.stdout).toContain("doctor");
+    expect(result.stdout).toContain("Diagnose common issues");
+  });
+});

--- a/test/lib/doctor.test.ts
+++ b/test/lib/doctor.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runDiagnostics } from "../../src/lib/doctor.js";
+import { createTask } from "../../src/lib/tasks.js";
+import { type TestEnv, createTestEnv } from "../helpers/setup.js";
+
+describe("doctor diagnostics", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  it("returns a valid DiagnosticReport structure", () => {
+    const report = runDiagnostics();
+    expect(report).toHaveProperty("checks");
+    expect(report).toHaveProperty("hasFail");
+    expect(report).toHaveProperty("hasWarn");
+    expect(Array.isArray(report.checks)).toBe(true);
+    expect(typeof report.hasFail).toBe("boolean");
+    expect(typeof report.hasWarn).toBe("boolean");
+  });
+
+  it("includes checks for each agent preset", () => {
+    const report = runDiagnostics();
+    const agentChecks = report.checks.filter((c) => c.name.startsWith("agent-"));
+    expect(agentChecks).toHaveLength(4); // claude, codex, gemini, aider
+    for (const check of agentChecks) {
+      expect(["pass", "warn"]).toContain(check.status);
+    }
+  });
+
+  it("returns pass for directories in test environment", () => {
+    const report = runDiagnostics();
+    const dirChecks = report.checks.filter((c) => c.name.startsWith("dir-"));
+    expect(dirChecks.length).toBeGreaterThanOrEqual(3);
+    for (const check of dirChecks) {
+      expect(check.status).toBe("pass");
+    }
+  });
+
+  it("returns pass for launchctl when REVEILLE_SKIP_LAUNCHCTL is set", () => {
+    const report = runDiagnostics();
+    const launchctlCheck = report.checks.find((c) => c.name === "launchctl");
+    expect(launchctlCheck).toBeDefined();
+    expect(launchctlCheck?.status).toBe("pass");
+    expect(launchctlCheck?.message).toContain("skipped");
+  });
+
+  it("returns no task checks when no tasks exist", () => {
+    const report = runDiagnostics();
+    const taskChecks = report.checks.filter((c) => c.name.startsWith("task-"));
+    expect(taskChecks).toHaveLength(0);
+  });
+
+  it("returns fail for task with missing working directory", () => {
+    createTask({
+      name: "Bad Task",
+      agent: "custom",
+      command: "echo test",
+      workingDir: "/nonexistent/path/abc123xyz",
+      scheduleType: "manual",
+    });
+
+    const report = runDiagnostics();
+    const workdirCheck = report.checks.find(
+      (c) => c.name.includes("workdir") && c.status === "fail",
+    );
+    expect(workdirCheck).toBeDefined();
+    expect(workdirCheck?.message).toContain("Working directory missing");
+    expect(report.hasFail).toBe(true);
+  });
+
+  it("returns pass for task with existing working directory", () => {
+    createTask({
+      name: "Good Task",
+      agent: "custom",
+      command: "echo test",
+      workingDir: "/tmp",
+      scheduleType: "manual",
+    });
+
+    const report = runDiagnostics();
+    const workdirCheck = report.checks.find(
+      (c) => c.name.includes("workdir") && c.status === "pass",
+    );
+    expect(workdirCheck).toBeDefined();
+    expect(workdirCheck?.message).toContain("Working directory exists");
+  });
+
+  it("returns fail for enabled task without plist file", () => {
+    createTask({
+      name: "No Plist Task",
+      agent: "claude",
+      command: "echo test",
+      workingDir: "/tmp",
+      scheduleType: "cron",
+      scheduleCron: "0 9 * * *",
+    });
+
+    const report = runDiagnostics();
+    const plistCheck = report.checks.find((c) => c.name.includes("plist") && c.status === "fail");
+    expect(plistCheck).toBeDefined();
+    expect(plistCheck?.message).toContain("Plist file missing");
+  });
+
+  it("hasFail is false when all checks pass or warn", () => {
+    // No tasks, only system checks — should all be pass or warn
+    const report = runDiagnostics();
+    // Remove agent checks that may be warn
+    const failChecks = report.checks.filter((c) => c.status === "fail");
+    if (failChecks.length === 0) {
+      expect(report.hasFail).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `reveille doctor` command that diagnoses common configuration issues (closes #7)
- Checks: reveille binary, agent binaries (claude/codex/gemini/aider), PATH config, directory permissions, launchctl connectivity, per-task health (working directory, plist, launchd load status)
- Exit code 1 when failures found, 0 otherwise

## Test plan
- [x] Unit tests (9 cases) for diagnostic logic
- [x] E2E tests (5 cases) for CLI output and exit codes
- [x] `npm run typecheck` passes
- [x] All 109 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)