### PR TITLE
Fix interval schedule input showing stale cron default

### DIFF
--- a/src/commands/add.tsx
+++ b/src/commands/add.tsx
@@ -14,6 +14,12 @@ import {
   getPreviousStep,
 } from "../lib/wizard-navigation.js";
 
+export function isValidInterval(value: string): boolean {
+  if (!value.trim()) return false;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0;
+}
+
 interface TaskDraft {
   name: string;
   agent: AgentId;
@@ -96,7 +102,9 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
         scheduleType: draft.scheduleType,
         scheduleCron: draft.scheduleType === "cron" ? draft.scheduleCron : undefined,
         scheduleIntervalSeconds:
-          draft.scheduleType === "interval" ? Number.parseInt(draft.scheduleCron) * 60 : undefined,
+          draft.scheduleType === "interval" && isValidInterval(draft.scheduleCron)
+            ? Number.parseInt(draft.scheduleCron, 10) * 60
+            : undefined,
         model,
         afterTask,
       });
@@ -219,7 +227,8 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
           <SelectInput
             items={scheduleItems}
             onSelect={(item) => {
-              const newDraft = { ...draft, scheduleType: item.value };
+              const resetCron = item.value === "interval" ? "" : "3 9 * * *";
+              const newDraft = { ...draft, scheduleType: item.value, scheduleCron: resetCron };
               setDraft(newDraft);
               setStep(
                 getNextStep("schedule-type", {
@@ -241,9 +250,14 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
           </Text>
           <TextInput
             value={draft.scheduleCron}
+            placeholder={draft.scheduleType === "interval" ? "30" : undefined}
             onChange={(v) => setDraft({ ...draft, scheduleCron: v })}
             onSubmit={(v) => {
-              if (v.trim()) setStep(getNextStep("schedule-value", stepContext));
+              if (draft.scheduleType === "interval") {
+                if (isValidInterval(v)) setStep(getNextStep("schedule-value", stepContext));
+              } else {
+                if (v.trim()) setStep(getNextStep("schedule-value", stepContext));
+              }
             }}
           />
           {draft.scheduleType === "cron" && draft.scheduleCron && (
@@ -255,6 +269,13 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
                   return "(invalid cron)";
                 }
               })()}
+            </Text>
+          )}
+          {draft.scheduleType === "interval" && draft.scheduleCron && (
+            <Text color="gray">
+              {isValidInterval(draft.scheduleCron)
+                ? `Every ${draft.scheduleCron} minutes`
+                : "(enter a positive integer)"}
             </Text>
           )}
         </Box>

--- a/src/commands/add.tsx
+++ b/src/commands/add.tsx
@@ -89,6 +89,12 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
     { label: "Manual only (run manually)", value: "manual" as ScheduleType },
   ];
 
+  function formatScheduleSummary(): string {
+    if (draft.scheduleType === "manual") return "Manual";
+    if (draft.scheduleType === "interval") return `Every ${draft.scheduleCron} minutes`;
+    return cronstrue.toString(draft.scheduleCron);
+  }
+
   function handleConfirm() {
     try {
       const model = draft.model || undefined;
@@ -227,8 +233,12 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
           <SelectInput
             items={scheduleItems}
             onSelect={(item) => {
-              const resetCron = item.value === "interval" ? "" : "3 9 * * *";
-              const newDraft = { ...draft, scheduleType: item.value, scheduleCron: resetCron };
+              const defaultScheduleValue = item.value === "interval" ? "" : "3 9 * * *";
+              const newDraft = {
+                ...draft,
+                scheduleType: item.value,
+                scheduleCron: defaultScheduleValue,
+              };
               setDraft(newDraft);
               setStep(
                 getNextStep("schedule-type", {
@@ -253,11 +263,9 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
             placeholder={draft.scheduleType === "interval" ? "30" : undefined}
             onChange={(v) => setDraft({ ...draft, scheduleCron: v })}
             onSubmit={(v) => {
-              if (draft.scheduleType === "interval") {
-                if (isValidInterval(v)) setStep(getNextStep("schedule-value", stepContext));
-              } else {
-                if (v.trim()) setStep(getNextStep("schedule-value", stepContext));
-              }
+              const isValid =
+                draft.scheduleType === "interval" ? isValidInterval(v) : v.trim() !== "";
+              if (isValid) setStep(getNextStep("schedule-value", stepContext));
             }}
           />
           {draft.scheduleType === "cron" && draft.scheduleCron && (
@@ -313,11 +321,7 @@ export function AddWizard({ onComplete, onCancel }: AddWizardProps = {}) {
           <Text> Directory: {draft.workingDir}</Text>
           <Text>
             {"  Schedule:  "}
-            {draft.scheduleType === "manual"
-              ? "Manual"
-              : draft.scheduleType === "cron"
-                ? cronstrue.toString(draft.scheduleCron)
-                : `Every ${draft.scheduleCron} minutes`}
+            {formatScheduleSummary()}
           </Text>
           {draft.afterTask && (
             <Text>

--- a/test/e2e/components/add.test.tsx
+++ b/test/e2e/components/add.test.tsx
@@ -1,0 +1,163 @@
+import { render } from "ink-testing-library";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AddWizard, isValidInterval } from "../../../src/commands/add.js";
+import { type TestEnv, createTestEnv } from "../../helpers/setup.js";
+
+const ENTER = "\r";
+const DOWN = "j";
+
+function delay(ms = 50): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("isValidInterval", () => {
+  it("accepts positive integers", () => {
+    expect(isValidInterval("1")).toBe(true);
+    expect(isValidInterval("30")).toBe(true);
+    expect(isValidInterval("1440")).toBe(true);
+  });
+
+  it("rejects zero", () => {
+    expect(isValidInterval("0")).toBe(false);
+  });
+
+  it("rejects negative numbers", () => {
+    expect(isValidInterval("-1")).toBe(false);
+    expect(isValidInterval("-30")).toBe(false);
+  });
+
+  it("rejects decimals", () => {
+    expect(isValidInterval("1.5")).toBe(false);
+    expect(isValidInterval("0.5")).toBe(false);
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(isValidInterval("abc")).toBe(false);
+    expect(isValidInterval("thirty")).toBe(false);
+  });
+
+  it("rejects cron expressions", () => {
+    expect(isValidInterval("3 9 * * *")).toBe(false);
+    expect(isValidInterval("*/5 * * * *")).toBe(false);
+  });
+
+  it("rejects empty and whitespace-only strings", () => {
+    expect(isValidInterval("")).toBe(false);
+    expect(isValidInterval("   ")).toBe(false);
+  });
+});
+
+describe("AddWizard component — interval schedule", () => {
+  let env: TestEnv;
+
+  beforeEach(() => {
+    env = createTestEnv();
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  /**
+   * Navigate the wizard to the schedule-value step with interval selected.
+   * Steps: name → agent → model → prompt → workdir → schedule-type(interval) → schedule-value
+   */
+  async function navigateToScheduleValue(stdin: { write: (data: string) => void }) {
+    // name step — type a name and submit
+    stdin.write("test-task");
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+
+    // agent step — select first (claude) by pressing enter
+    stdin.write(ENTER);
+    await delay();
+
+    // model step — leave empty, press enter
+    stdin.write(ENTER);
+    await delay();
+
+    // prompt step — type a prompt and submit
+    stdin.write("do something");
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+
+    // workdir step — accept default (cwd), press enter
+    stdin.write(ENTER);
+    await delay();
+
+    // schedule-type step — navigate to "interval" (2nd item) and select
+    stdin.write(DOWN); // move from cron to interval
+    await delay();
+    stdin.write(ENTER); // select interval
+    await delay();
+  }
+
+  it("clears cron default value when interval is selected", async () => {
+    const { lastFrame, stdin, cleanup } = render(<AddWizard onComplete={() => {}} />);
+    await delay();
+
+    await navigateToScheduleValue(stdin);
+
+    // Now at schedule-value step — the input should be empty (cron default cleared)
+    const frame = lastFrame()!;
+    expect(frame).toContain("Interval in minutes");
+    // The old cron default "3 9 * * *" should NOT appear
+    expect(frame).not.toContain("3 9 * * *");
+
+    cleanup();
+  });
+
+  it("does not advance from schedule-value with invalid interval input", async () => {
+    const { lastFrame, stdin, cleanup } = render(<AddWizard onComplete={() => {}} />);
+    await delay();
+
+    await navigateToScheduleValue(stdin);
+
+    // Type an invalid value (not a positive integer)
+    stdin.write("abc");
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+
+    // Should still be on schedule-value step
+    const frame = lastFrame()!;
+    expect(frame).toContain("Interval in minutes");
+
+    cleanup();
+  });
+
+  it("shows interval preview text for valid input", async () => {
+    const { lastFrame, stdin, cleanup } = render(<AddWizard onComplete={() => {}} />);
+    await delay();
+
+    await navigateToScheduleValue(stdin);
+
+    // Type a valid interval
+    stdin.write("30");
+    await delay();
+
+    const frame = lastFrame()!;
+    expect(frame).toContain("Every 30 minutes");
+
+    cleanup();
+  });
+
+  it("shows validation hint for invalid interval input", async () => {
+    const { lastFrame, stdin, cleanup } = render(<AddWizard onComplete={() => {}} />);
+    await delay();
+
+    await navigateToScheduleValue(stdin);
+
+    // Type an invalid interval value
+    stdin.write("abc");
+    await delay();
+
+    const frame = lastFrame()!;
+    expect(frame).toContain("(enter a positive integer)");
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- Reset `scheduleCron` when switching schedule type (interval→empty, cron→default)
- Add placeholder, validation, and preview for interval input in the add wizard
- Guard `handleConfirm` against NaN from invalid interval values

Closes #32

## Test results
- typecheck: ✅ pass
- lint: ✅ pass (warnings are pre-existing)
- test: ✅ 172 passed (19 suites)

### Added E2E tests
- `test/e2e/components/add.test.tsx` — 7 unit tests for `isValidInterval`, 4 component tests for wizard schedule-type switching, interval validation, and preview display

## Test plan
- [ ] Run `reveille add` interactively, select "Interval", verify input is empty (not "3 9 * * *")
- [ ] Enter "abc" as interval → should not advance to next step
- [ ] Enter "30" → should show "Every 30 minutes" preview and advance
- [ ] Switch back to "Cron" → verify default "3 9 * * *" is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)